### PR TITLE
Switch to python3 on Ubuntu 20.04

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,10 +11,10 @@
   with_items:
     - autoconf
     - build-essential
-    - python-setuptools
-    - python-software-properties
-    - python-dev
-    - python-pip
+    - python3-setuptools
+    - python3-software-properties
+    - python3-dev
+    - python3-pip
     - libncurses-dev
 
 # CIS CAT secuirty configurations

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -299,7 +299,7 @@
     - x_window
 
 - name: disable apport
-  lineinfile: dest=/etc/init/apport.conf regexp="^env enabled" line="env enabled=0"
+  lineinfile: dest=/etc/default/apport regexp="^enabled" line="enabled=0"
   become: true
   tags:
     - cis_cat_security

--- a/roles/sentry/defaults/main.yml
+++ b/roles/sentry/defaults/main.yml
@@ -4,6 +4,8 @@ other_python_pkgs:
   - libffi-dev
   - libjpeg-dev
   - libxml2-dev
+  - libxmlsec1-dev
+  - libxmlsec1-openssl
   - libxslt-dev
   - libyaml-dev
   - libpq-dev
@@ -18,4 +20,4 @@ other_python_pkgs:
   - libblas-dev
   - liblapack-dev
   - libatlas-base-dev
-  - python-passlib
+  - python3-passlib

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -7,7 +7,7 @@
     - python
 
 - name: Install all relevant files for server
-  pip: name={{item}} executable=pip
+  pip: name={{item}} executable=pip3
   with_items:
     - urllib3
     - pyopenssl
@@ -18,7 +18,7 @@
     - python
 
 - name: install python mysql bindings for mysql commands
-  apt: name=python-mysqldb state=installed
+  apt: name=python-mysqldb state=present
   tags:
     - python
 

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -18,7 +18,7 @@
     - python
 
 - name: install python mysql bindings for mysql commands
-  apt: name=python-mysqldb state=present
+  apt: name=python3-mysqldb state=present
   tags:
     - python
 

--- a/site.yml
+++ b/site.yml
@@ -11,7 +11,7 @@
     - name: Update apt packages
       raw: apt-get update
     - name: Install python
-      raw: apt-get install python-minimal aptitude -y
+      raw: apt-get install python3 aptitude -y
     - name: Gather facts
       action: setup
   become: yes
@@ -28,7 +28,7 @@
     - name: Update apt packages
       raw: apt-get update
     - name: Install python
-      raw: apt-get install python-minimal aptitude -y
+      raw: apt-get install python3 aptitude -y
     - name: Gather facts
       action: setup
   become: yes # become sudo


### PR DESCRIPTION
We cannot use our current stack to recreate our sentry environment.
The EC2 instance fails to run the playbook with the following message:
```
CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography import utils, x509
```